### PR TITLE
Comma in "first-in, first-out"

### DIFF
--- a/dissertation/chapter1/main.tex
+++ b/dissertation/chapter1/main.tex
@@ -77,7 +77,7 @@ possibilities include:
   (KPNs)~\cite{Kahn-1974}, as well as in the more restricted
   \emph{synchronous data flow} systems~\cite{Lee-sdn}, a network of
   independent ``computing stations'' communicate with each other
-  through first-in first-out (FIFO) queues, or \emph{channels}.
+  through first-in, first-out (FIFO) queues, or \emph{channels}.
   Reading data out of such a FIFO queue is a \emph{blocking}
   operation: once an attempt to read has started, a computing station
   cannot do anything else until the data to be read is available.


### PR DESCRIPTION
Most references to FIFO expand the acronym as "first-in, first-out," including a separating comma.
